### PR TITLE
Fix link args on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use [mrml] v0.4.0
+
+### Fixed
+- Warning about special link args for x86_64-apple-darwin target
 
 ## [0.2.0] – 2020-10-19
 ### Changed

--- a/native/mjml_nif/.cargo/config
+++ b/native/mjml_nif/.cargo/config
@@ -1,0 +1,5 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/native/mjml_nif/Cargo.lock
+++ b/native/mjml_nif/Cargo.lock
@@ -64,7 +64,7 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "mjml_nif"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "mrml",
  "rustler",

--- a/native/mjml_nif/Cargo.toml
+++ b/native/mjml_nif/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mjml_nif"
-version = "0.1.0"
-authors = []
+version = "0.2.0"
+authors = ["Paul Götze"]
 edition = "2018"
 
 [lib]


### PR DESCRIPTION
Fixes the warning described in #6 by adding a .cargo/config with respective mentioned rustflags.