### PR TITLE
Misc doc changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # The directory Mix will write compiled artifacts to.
 /_build/
 
-# The directory that rustler will write compiled artifacts to.
-/priv
-
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
 
@@ -25,6 +22,11 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 mjml-*.tar
 
-# The directory that rust will compile to for testing.
-/native/mjml_nif/target
+# Temporary files, for example, from tests.
+/tmp/
 
+# The directory that rustler will write compiled artifacts to.
+/priv/
+
+# The directory that rust will compile to for testing.
+/native/mjml_nif/target/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 For clarity, major releases of mjml_nif use the respective [mrml] releases with the same major release number.
-I.e. mjml_nif 0.x versions use mrml versions >= 0.1, < 1.0.0, and mjml_nif 1.x versions use mrml versions >= 1.0.0, < 2.0.0, etc.
+I.e. `mjml_nif 0.x` versions use mrml versions `>= 0.1, < 1.0.0`, and `mjml_nif 1.x` versions use mrml versions `>= 1.0.0, < 2.0.0`, etc.
 
 ## [Unreleased]
 ### Changed

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2020–2021, Paul Götze
+Copyright (c) 2020 Paul Götze
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # MJML (Rust NIFs for Elixir)
 
-[![Hex version badge](https://img.shields.io/hexpm/v/mjml.svg)](https://hex.pm/packages/mjml)
-[![License badge](https://img.shields.io/hexpm/l/mjml.svg)](https://github.com/adoptoposs/mjml_nif/blob/main/LICENSE.md)
 [![Build Status](https://github.com/adoptoposs/mjml_nif/workflows/Tests/badge.svg)](https://github.com/adoptoposs/mjml_nif/workflows/Tests/badge.svg)
+[![Module Version](https://img.shields.io/hexpm/v/mjml.svg)](https://hex.pm/packages/mjml)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/mjml/)
+[![Total Download](https://img.shields.io/hexpm/dt/mjml.svg)](https://hex.pm/packages/mjml)
+[![License](https://img.shields.io/hexpm/l/mjml.svg)](https://github.com/adoptoposs/mjml_nif/blob/master/LICENSE.md)
+[![Last Updated](https://img.shields.io/github/last-commit/adoptoposs/mjml_nif.svg)](https://github.com/adoptoposs/mjml_nif/commits/master)
 
 Native Implemented Function (NIF) bindings for the [MJML](https://mjml.io) Rust implementation ([mrml](https://github.com/jdrouet/mrml)).
 
@@ -22,7 +25,7 @@ end
 
 ## Usage
 
-Transpile MJML templates to HTML with: 
+Transpile MJML templates to HTML with:
 
 ```elixir
 mjml = "<mjml>...</mjml>"
@@ -46,8 +49,8 @@ Most Heroku buildpacks for Elixir do not come with Rust installed; you will need
 
 For example:
 ```bash
-heroku buildpacks:add -i 1 https://github.com/emk/heroku-buildpack-rust.git
-echo "RUST_SKIP_BUILD=1" > RustConfig
+$ heroku buildpacks:add -i 1 https://github.com/emk/heroku-buildpack-rust.git
+$ echo "RUST_SKIP_BUILD=1" > RustConfig
 ```
 
 ### Deploying with Docker
@@ -70,15 +73,15 @@ RUSTFLAGS='--codegen target-feature=-crt-static'
 
 ## Contributing
 
-We encourage you to contribute to mjml_nif. 
-Please check our [CONTRIBUTING.md](https://github.com/adoptoposs/mjml_nif/blob/main/CONTRIBUTING.md) guides for more information.
+We encourage you to contribute to mjml_nif.
+Please check our [CONTRIBUTING.md](./CONTRIBUTING.md) guides for more information.
 
-This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to our [CODE_OF_CONDUCT.md](https://github.com/adoptoposs/mjml_nif/blob/main/CODE_OF_CONDUCT.md).
+This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to our [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
 
 
-## License
+## Copyright and License
 
-Copyright (c) 2020-2021, Paul Götze
+Copyright (c) 2020 Paul Götze
 
-This software is licensed under the [MIT License](https://github.com/adoptoposs/mjml_nif/blob/main/LICENSE.md).
-
+This work is free. You can redistribute it and/or modify it under the
+terms of the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule Mjml.MixProject do
       main: "readme",
       extras: [
         "CHANGELOG.md": [],
+        "CONTRIBUTING.md": [title: "Contributing"],
         "CODE_OF_CONDUCT.md": [title: "Code of Conduct"],
         "LICENSE.md": [title: "License"],
         "README.md": [title: "Overview"]

--- a/mix.exs
+++ b/mix.exs
@@ -1,19 +1,17 @@
 defmodule Mjml.MixProject do
   use Mix.Project
 
-  @github_url "https://github.com/adoptoposs/mjml_nif"
+  @source_url "https://github.com/adoptoposs/mjml_nif"
+  @version "1.1.1"
 
   def project do
     [
       app: :mjml,
-      version: "1.1.1",
+      version: @version,
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       compilers: Mix.compilers(),
       name: "mjml",
-      description: description(),
-      source_url: @github_url,
-      homepage_url: @github_url,
       package: package(),
       docs: docs(),
       deps: deps()
@@ -31,27 +29,33 @@ defmodule Mjml.MixProject do
   defp deps do
     [
       {:rustler, "~> 0.21"},
-      {:ex_doc, "~> 0.23", only: :dev, runtime: false}
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end
 
-  defp description() do
-    "NIF bindings for the MJML Rust implementation (mrml)"
-  end
-
-  defp package() do
+  defp package do
     [
+      description: "NIF bindings for the MJML Rust implementation (mrml)",
       maintainers: ["Paul Götze"],
       licenses: ["MIT"],
       files: ~w(lib native .formatter.exs README* LICENSE* mix.exs),
-      links: %{"GitHub" => @github_url}
+      links: %{"GitHub" => @source_url}
     ]
   end
 
-  defp docs() do
+  defp docs do
     [
       main: "readme",
-      extras: ["README.md"]
+      extras: [
+        "CHANGELOG.md": [],
+        "CODE_OF_CONDUCT.md": [title: "Code of Conduct"],
+        "LICENSE.md": [title: "License"],
+        "README.md": [title: "Overview"]
+      ],
+      source_url: @source_url,
+      source_ref: "v#{@version}",
+      homepage_url: @source_url,
+      formatters: ["html"]
     ]
   end
 end


### PR DESCRIPTION
Besides other documentation changes, this commit ensures the generated
HTML doc for HexDocs.pm will become the source of truth for this Elixir
library and leverage on latest features of ExDoc.