### PR TITLE
Use Rustler Precompiled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,220 @@
+name: Build precompiled NIFs
+
+env:
+  NIF_DIRECTORY: "native/mjml_nif"
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+
+defaults:
+  run:
+    # Sets the working dir for "run" scripts.
+    # Note that this won't change the directory for actions (tasks with "uses").
+    working-directory: "./native/mjml_nif"
+
+jobs:
+  build_release:
+    name: NIF ${{ matrix.job.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          # NIF version 2.16
+          - {
+              target: arm-unknown-linux-gnueabihf,
+              os: ubuntu-20.04,
+              nif: "2.16",
+              use-cross: true,
+            }
+          - {
+              target: aarch64-unknown-linux-gnu,
+              os: ubuntu-20.04,
+              nif: "2.16",
+              use-cross: true,
+            }
+          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.16" }
+          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.16" }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16" }
+          - {
+              target: x86_64-unknown-linux-musl,
+              os: ubuntu-20.04,
+              nif: "2.16",
+              use-cross: true,
+            }
+          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.16" }
+          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.16" }
+          # NIF version 2.15
+          - {
+              target: arm-unknown-linux-gnueabihf,
+              os: ubuntu-20.04,
+              nif: "2.15",
+              use-cross: true,
+            }
+          - {
+              target: aarch64-unknown-linux-gnu,
+              os: ubuntu-20.04,
+              nif: "2.15",
+              use-cross: true,
+            }
+          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.15" }
+          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.15" }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15" }
+          - {
+              target: x86_64-unknown-linux-musl,
+              os: ubuntu-20.04,
+              nif: "2.15",
+              use-cross: true,
+            }
+          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.15" }
+          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.15" }
+          # # NIF version 2.14
+          - {
+              target: arm-unknown-linux-gnueabihf,
+              os: ubuntu-20.04,
+              nif: "2.14",
+              use-cross: true,
+            }
+          - {
+              target: aarch64-unknown-linux-gnu,
+              os: ubuntu-20.04,
+              nif: "2.14",
+              use-cross: true,
+            }
+          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.14" }
+          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.14" }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14" }
+          - {
+              target: x86_64-unknown-linux-musl,
+              os: ubuntu-20.04,
+              nif: "2.14",
+              use-cross: true,
+            }
+          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.14" }
+          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.14" }
+
+    env:
+      RUSTLER_NIF_VERSION: ${{ matrix.job.nif }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Install prerequisites
+        shell: bash
+        run: |
+          case ${{ matrix.job.target }} in
+            arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
+          esac
+
+      - name: Extract crate information
+        shell: bash
+        run: |
+          echo "PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
+          # Get the project version from mix.exs
+          echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' ../../mix.exs | head -n1)" >> $GITHUB_ENV
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.job.target }}
+          override: true
+          profile: minimal
+
+      - name: Show version information (Rust, cargo, GCC)
+        shell: bash
+        run: |
+          gcc --version || true
+          rustup -V
+          rustup toolchain list
+          rustup default
+          cargo -V
+          rustc -V
+          rustc --print=cfg
+
+      - name: Download cross from GitHub releases
+        uses: giantswarm/install-binary-action@v1.0.0
+        if: ${{ matrix.job.use-cross }}
+        with:
+          binary: "cross"
+          version: "v0.2.1"
+          download_url: "https://github.com/rust-embedded/cross/releases/download/${version}/cross-${version}-x86_64-unknown-linux-gnu.tar.gz"
+          tarball_binary_path: "${binary}"
+          smoke_test: "${binary} --version"
+
+      - name: Build
+        shell: bash
+        run: |
+          if [ "${{ matrix.job.use-cross }}" == "true" ]; then
+            cross build --release --target=${{ matrix.job.target }}
+          else
+            cargo build --release --target=${{ matrix.job.target }}
+          fi
+
+      - name: Rename lib to the final name
+        id: rename
+        shell: bash
+        run: |
+          LIB_PREFIX="lib"
+          case ${{ matrix.job.target }} in
+            *-pc-windows-*) LIB_PREFIX="" ;;
+          esac;
+
+          # Figure out suffix of lib
+          # See: https://doc.rust-lang.org/reference/linkage.html
+          LIB_SUFFIX=".so"
+          case ${{ matrix.job.target }} in
+            *-apple-darwin) LIB_SUFFIX=".dylib" ;;
+            *-pc-windows-*) LIB_SUFFIX=".dll" ;;
+          esac;
+
+          CICD_INTERMEDIATES_DIR=$(mktemp -d)
+
+          # Setup paths
+          LIB_DIR="${CICD_INTERMEDIATES_DIR}/released-lib"
+          mkdir -p "${LIB_DIR}"
+          LIB_NAME="${LIB_PREFIX}${{ env.PROJECT_NAME }}${LIB_SUFFIX}"
+          LIB_PATH="${LIB_DIR}/${LIB_NAME}"
+
+          # Copy the release build lib to the result location
+          cp "target/${{ matrix.job.target }}/release/${LIB_NAME}" "${LIB_DIR}"
+
+          # Final paths
+          # In the end we use ".so" for MacOS in the final build
+          # See: https://www.erlang.org/doc/man/erlang.html#load_nif-2
+          LIB_FINAL_SUFFIX="${LIB_SUFFIX}"
+          case ${{ matrix.job.target }} in
+            *-apple-darwin) LIB_FINAL_SUFFIX=".so" ;;
+          esac;
+
+          LIB_FINAL_NAME="${LIB_PREFIX}${PROJECT_NAME}-v${PROJECT_VERSION}-nif-${RUSTLER_NIF_VERSION}-${{ matrix.job.target }}${LIB_FINAL_SUFFIX}"
+
+          # Copy lib to final name on this directory
+          cp "${LIB_PATH}" "${LIB_FINAL_NAME}"
+
+          tar -cvzf "${LIB_FINAL_NAME}.tar.gz" "${LIB_FINAL_NAME}"
+
+          # Passes the path relative to the root of the project.
+          LIB_FINAL_PATH="${NIF_DIRECTORY}/${LIB_FINAL_NAME}.tar.gz"
+
+          # Let subsequent steps know where to find the lib
+          echo ::set-output name=LIB_FINAL_PATH::${LIB_FINAL_PATH}
+          echo ::set-output name=LIB_FINAL_NAME::${LIB_FINAL_NAME}.tar.gz
+
+      - name: "Artifact upload"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.rename.outputs.LIB_FINAL_NAME }}
+          path: ${{ steps.rename.outputs.LIB_FINAL_PATH }}
+
+      - name: Publish archives and packages
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ${{ steps.rename.outputs.LIB_FINAL_PATH }}
+        if: startsWith(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Native Implemented Function (NIF) bindings for the [MJML](https://mjml.io) Rust 
 
 ## Installation
 
-In order to use the package you need to [install Rust](https://www.rust-lang.org/tools/install).
-
 The package can be installed by adding `mjml` to your list of dependencies in `mix.exs`:
 
 ```elixir
@@ -21,6 +19,15 @@ def deps do
     {:mjml, "~> 1.2.0"}
   ]
 end
+```
+
+By default **you don't need Rust installed** because the lib will try to download
+a precompiled NIF file. In case you want to force compilation set the
+`MJML_BUILD` environment variable to `true` or `1`. Alternatively you can also set the
+application env in order to force the build:
+
+```elixir
+config :rustler_precompiled, :force_build, mjml: true
 ```
 
 ## Usage
@@ -34,41 +41,6 @@ mjml = "<mjml>...</mjml>"
 # For an invalid MJML template:
 mjml = "something not MJML"
 {:error, message} = Mjml.to_html(mjml)
-```
-
-## Deployment
-
-MJML requires that the Rust compiler be [installed](https://www.rust-lang.org/tools/install) wherever MJML is compiled.
-
-### Deploying to Heroku
-
-Most Heroku buildpacks for Elixir do not come with Rust installed; you will need to:
-
-- Add a Rust buildpack to your app, setting it to run before Elixir; and
-- Add a `RustConfig` file to your project's root directory, with `RUST_SKIP_BUILD=1` set.
-
-For example:
-```bash
-$ heroku buildpacks:add -i 1 https://github.com/emk/heroku-buildpack-rust.git
-$ echo "RUST_SKIP_BUILD=1" > RustConfig
-```
-
-### Deploying with Docker
-
-Make sure Rust is installed prior to running `mix deps.compile`. You can see examples of what commands to include in your Dockerfile by looking at the official Rust Dockerfiles. For example, here are the commands for [`alpine3.11`](https://github.com/rust-lang/docker-rust/blob/009cc0a821ff773d54875350312731ed490d5cce/1.43.1/alpine3.11/Dockerfile) based images.
-
-If your Dockerfile is separated into a build stage and a release stage Rust only needs to be installed on the build stage. **However**, your release stage will need to have `libgcc` installed.
-
-Alpine, for example, does not include `libgcc` by default and you will need to install it.
-
-```
-RUN apk add --no-cache libgcc
-```
-
-You will also need to have the following environment variable set during the `build` stage or else `mix compile` will fail.
-
-```
-RUSTFLAGS='--codegen target-feature=-crt-static'
 ```
 
 ## Contributing

--- a/lib/mjml.ex
+++ b/lib/mjml.ex
@@ -3,7 +3,16 @@ defmodule Mjml do
   Provides functions for transpiling MJML email templates to HTML.
   """
 
-  use Rustler, otp_app: :mjml, crate: "mjml_nif"
+  mix_config = Mix.Project.config()
+  version = mix_config[:version]
+  github_url = mix_config[:package][:links]["GitHub"]
+
+  use RustlerPrecompiled,
+    otp_app: :mjml,
+    crate: "mjml_nif",
+    base_url: "#{github_url}/releases/download/v#{version}",
+    force_build: System.get_env("MJML_BUILD") in ["1", "true"],
+    version: version
 
   @doc """
   Converts an MJML string to HTML content.

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Mjml.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:rustler, "~> 0.24"},
+      {:rustler_precompiled, "~> 0.2.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end
@@ -38,7 +38,7 @@ defmodule Mjml.MixProject do
       description: "NIF bindings for the MJML Rust implementation (mrml)",
       maintainers: ["Paul Götze"],
       licenses: ["MIT"],
-      files: ~w(lib native .formatter.exs README* LICENSE* mix.exs),
+      files: ~w(lib native .formatter.exs README* LICENSE* mix.exs checksum-*.exs),
       links: %{"GitHub" => @source_url}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "earmark": {:hex, :earmark, "1.4.10", "bddce5e8ea37712a5bfb01541be8ba57d3b171d3fa4f80a0be9bcf1db417bcaf", [:mix], [{:earmark_parser, ">= 1.4.10", [hex: :earmark_parser, repo: "hexpm", optional: false]}], "hexpm", "12dbfa80810478e521d3ffb941ad9fbfcbbd7debe94e1341b4c4a1b2411c1c27"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.20", "89970db71b11b6b89759ce16807e857df154f8df3e807b2920a8c39834a9e5cf", [:mix], [], "hexpm", "1eb0d2dabeeeff200e0d17dc3048a6045aab271f73ebb82e416464832eb57bdd"},
   "ex_doc": {:hex, :ex_doc, "0.28.2", "e031c7d1a9fc40959da7bf89e2dc269ddc5de631f9bd0e326cbddf7d8085a9da", [:mix], [{:earmark_parser, "~> 1.4.19", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "51ee866993ffbd0e41c084a7677c570d0fc50cb85c6b5e76f8d936d9587fa719"},
@@ -8,5 +9,6 @@
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.2", "b99ca56bbce410e9d5ee4f9155a212e942e224e259c7ebbf8f2c86ac21d4fa3c", [:mix], [], "hexpm", "98d51bd64d5f6a2a9c6bb7586ee8129e27dfaab1140b5a4753f24dac0ba27d2f"},
   "rustler": {:hex, :rustler, "0.24.0", "b8362a2fee1c9d2c7373b0bfdc98f75bbc02864efcec50df173fe6c4f72d4cc4", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:toml, "~> 0.6", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "2773167fca68a6525822ad977b41368ea3c2af876c42ebaa7c9d6bb69b67f1ce"},
+  "rustler_precompiled": {:hex, :rustler_precompiled, "0.2.0", "8cb0fb2527d51de624e91b45e0a2b12c92e1cb614f8616f8dfc07c3d1180f48a", [:mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:rustler, "~> 0.23", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm", "583be3d480fa292770d45d4e20418ad81b6d9acd2bc42d8776e79f4a283cbae4"},
   "toml": {:hex, :toml, "0.6.2", "38f445df384a17e5d382befe30e3489112a48d3ba4c459e543f748c2f25dd4d1", [:mix], [], "hexpm", "d013e45126d74c0c26a38d31f5e8e9b83ea19fc752470feb9a86071ca5a672fa"},
 }

--- a/native/mjml_nif/.cargo/config
+++ b/native/mjml_nif/.cargo/config
@@ -1,5 +1,23 @@
-[target.'cfg(target_os = "macos")']
+[profile.release]
+lto = true
+
+[target.x86_64-apple-darwin]
 rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+# See https://github.com/rust-lang/rust/issues/59302
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=-crt-static"
 ]


### PR DESCRIPTION
This PR introduces [rustler_precompiled](https://github.com/philss/rustler_precompiled). This change enables users to use `mjml` without the Rust compiler. I referred to [philss/rustler_precompilation_example](https://github.com/philss/rustler_precompilation_example).

Note this change introduces an additional step on release.
- `mix rustler_precompiled.download Mjml --all` before `mix hex.publish` and after creating release binaries by pushing a tag.

