### PR TITLE
Add Cross.toml in order to pass the NIF version to cross

### DIFF
--- a/native/mjml_nif/Cross.toml
+++ b/native/mjml_nif/Cross.toml
@@ -1,0 +1,4 @@
+[build.env]
+passthrough = [
+  "RUSTLER_NIF_VERSION"
+]


### PR DESCRIPTION
This is important because `cross` don't have access by default to the
env vars of the system.

This is related to https://github.com/philss/rustler_precompiled/issues/23

PS: it's a good idea to release a new patch version with this fix, since people using targets that are compiled with Cross before OTP 24 (NIF versions 2.14 and 2.15) are affected.