### PR TITLE
CI: Update OTP 26 & Elixir v15 versions in test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,18 +22,18 @@ jobs:
       # For compatibility between Elixir & Erlang/OTP see
       # https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
       matrix:
-        otp: [24.3, 25.1, 26.0]
-        elixir: [1.11.4, 1.12.3, 1.13.4, 1.14.5, 1.15.0]
+        otp: [24.3, 25.1, 26.1]
+        elixir: [1.11.4, 1.12.3, 1.13.4, 1.14.5, 1.15.6]
         exclude:
           - otp: 25.1
             elixir: 1.11.4
           - otp: 25.1
             elixir: 1.12.3
-          - otp: 26.0
+          - otp: 26.1
             elixir: 1.11.4
-          - otp: 26.0
+          - otp: 26.1
             elixir: 1.12.3
-          - otp: 26.0
+          - otp: 26.1
             elixir: 1.13.4
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updates the test matrix versions:

* OTP 26.1
* Elixir 1.15.6