### PR TITLE
feat: upgrade to mrml v6.0 to allow conditional comments and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ I.e. `mjml_nif 0.x` versions use mrml versions `>= 0.1, < 1.0.0`, and `mjml_nif 
 
 ## [Unreleased]
 
+## [6.0.0] - 2025-06-14
+
+### Changed
+- Use [mrml] v6.0.0, which introduces API-breaking changes (see their [release log](https://github.com/jdrouet/mrml/releases/tag/mrml-v6.0.0, also see [mrml diff v5.0.0..v6.0.0][mrml-v5.0.0-v6.0.0]), enables conditional comments, updates resource handling, and fixes layout issues with mj-divider. It removes use of deprecated render options due to changes in mrml::prelude::render::Options.
+- Use rustler v0.36.2
+
+---
+
 ## [5.0.0] - 2025-03-24
 
 ### Changed
@@ -195,6 +203,7 @@ I.e. `mjml_nif 0.x` versions use mrml versions `>= 0.1, < 1.0.0`, and `mjml_nif 
 Initial release
 
 [Unreleased]: https://github.com/adoptoposs/mjml_nif/compare/v5.0.0...HEAD
+[6.0.0]: https://github.com/adoptoposs/mjml_nif/compare/v5.0.0...v6.0.0
 [5.0.0]: https://github.com/adoptoposs/mjml_nif/compare/v4.0.0...v5.0.0
 [4.0.0]: https://github.com/adoptoposs/mjml_nif/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/adoptoposs/mjml_nif/compare/v3.0.3...v3.1.0
@@ -223,6 +232,7 @@ Initial release
 [0.1.0]: https://github.com/adoptoposs/mjml_nif/compare/e77d33e9bcb58e0e2e9e522322d97ebdcb212618...v0.1.0
 [mrml]: https://github.com/jdrouet/mrml
 
+[mrml-v5.0.0-v6.0.0]: https://github.com/jdrouet/mrml/compare/mrml-v5.0.0...mrml-v6.0.0
 [mrml-v4.0.1-v5.0.0]: https://github.com/jdrouet/mrml/compare/mrml-v4.0.1...mrml-v5.0.0
 [mrml-v3.1.5-v4.0.1]: https://github.com/jdrouet/mrml/compare/mrml-v3.1.5...mrml-v4.0.1
 [mrml-v3.0.4-v3.1.5]: https://github.com/jdrouet/mrml/compare/mrml-v3.0.4...mrml-v3.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ I.e. `mjml_nif 0.x` versions use mrml versions `>= 0.1, < 1.0.0`, and `mjml_nif 
 ## [6.0.0] - 2025-06-14
 
 ### Changed
-- Use [mrml] v6.0.0, which introduces API-breaking changes (see their [release log](https://github.com/jdrouet/mrml/releases/tag/mrml-v6.0.0, also see [mrml diff v5.0.0..v6.0.0][mrml-v5.0.0-v6.0.0]), enables conditional comments, updates resource handling, and fixes layout issues with mj-divider. It removes use of deprecated render options due to changes in mrml::prelude::render::Options.
+- Use [mrml] v6.0.0, which enables conditional comments, updates resource handling and fixes layout issues with mj-divider (see their [release log](https://github.com/jdrouet/mrml/releases/tag/mrml-v6.0.0), also see [mrml diff v5.0.0..v6.0.0][mrml-v5.0.0-v6.0.0]).
 - Use rustler v0.36.2
 
 ---

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Mjml.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/adoptoposs/mjml_nif"
-  @version "5.0.0"
+  @version "6.0.0"
 
   def project do
     [

--- a/native/mjml_nif/Cargo.lock
+++ b/native/mjml_nif/Cargo.lock
@@ -71,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "mjml_nif"
-version = "5.0.0"
+version = "6.0.0-pre"
 dependencies = [
  "mrml",
  "rustler",
@@ -98,9 +98,8 @@ dependencies = [
 
 [[package]]
 name = "mrml"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9daf3c183141de1d3d2db6f275536c70ebfb87b11ed4b0c709b1103d1c9d3ede"
+version = "6.0.0"
+source = "git+https://github.com/jdrouet/mrml?branch=release-plz-2025-05-20T12-58-25Z#35276756735d6b0a659eee52257cf072d563f1f2"
 dependencies = [
  "enum-as-inner",
  "htmlparser",
@@ -184,18 +183,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/native/mjml_nif/Cargo.toml
+++ b/native/mjml_nif/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "mjml_nif"
-version = "5.0.0"
+# TODO: when officially released:
+# version = "6.0.0"
+version = "6.0.0-pre"
 authors = ["Paul Götze"]
 edition = "2021"
 
@@ -11,7 +13,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.36.2"
-mrml = { version = "5.0", default-features = false, features = ["parse", "render"] }
+# TODO: when officially released:
+# mrml = { version = "6.0", default-features = false, features = ["parse", "render"] }
+mrml = { git = "https://github.com/jdrouet/mrml", branch = "release-plz-2025-05-20T12-58-25Z", default-features = false, features = ["parse", "render"] }
 
 [features]
 default = ["nif_version_2_15"]

--- a/test/mjml_test.exs
+++ b/test/mjml_test.exs
@@ -152,5 +152,25 @@ defmodule MjmlTest do
       assert html =~ "Open Sans"
       assert html =~ "https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700"
     end
+
+    test "transpiles MJML with conditional comments" do
+      mjml = """
+        <mjml>
+          <mj-body>
+            <!-- comment -->
+            <mj-raw>
+              <!--[if mso]>
+                <p>This is a conditional comment for Outlook</p>
+              <![endif]-->
+            </mj-raw>
+          </mj-body>
+        </mjml>
+      """
+
+      assert {:ok, html} = Mjml.to_html(mjml, keep_comments: false)
+      refute html =~ "<!-- comment -->"
+      assert html =~ "<!--[if mso]>"
+      assert html =~ "<p>This is a conditional comment for Outlook</p>"
+    end
   end
 end


### PR DESCRIPTION
## Upgrade to mrml 6.0

This PR updates `mjml_nif` to use `mrml 6.0`, which introduces several improvements and breaking changes:

- Updates mrml from v5 to v6.0 (currently tracked via branch — see two `TODO`s to update once released).
- Adds a test verifying that conditional comments can now be handled (a feature I [contributed upstream](https://github.com/jdrouet/mrml/pull/533)).
  + Removing comments option is just to show they don't interfere.
- Reviewed all "API breaking" [changes](https://github.com/jdrouet/mrml/pull/547) and I don't see anything affecting us (e.g., `mrml::prelude::render::Options`)
- Validated against real templates in a separate sample project, including previously broken edge cases (e.g. `mj-divider` rendering, style fixes). See below tests to compare v5 with v6.

Once mrml 6.0 is officially released, only the two `TODO` lines in `Cargo.toml` need to be updated.

Feel free to change and merge it while I'm away, since I will take vacations soon.

### Tests

Using the sample project, having these tests:

```elixir
defmodule MjmlNifTest do
  use ExUnit.Case

  @valid_mjml """
  <mjml>
    <mj-body>
      <mj-section>
        <mj-column>
          <mj-text>Hello, world!</mj-text>
          <mj-divider border-color="#F45E43" width="50%" align="left"></mj-divider>
        </mj-column>
      </mj-section>
    </mj-body>
  </mjml>
  """

  @invalid_mjml "not valid mjml at all"

  @mjml_with_conditional_comment """
  <mjml>
    <mj-body>
      <mj-raw>
        <!--[if mso]>
          <p>This is a conditional comment for Outlook</p>
        <![endif]-->
      </mj-raw>
    </mj-body>
  </mjml>
  """

  test "renders valid MJML input into HTML with proper mj-divider styles" do
    assert {:ok, html} = Mjml.to_html(@valid_mjml)
    assert html =~ "<!doctype html>"
    assert html =~ "Hello, world!"
    
    # not using Floki because it fails with conditional comments
    # Match <p ... style="...border-top...">...</p>
    p_tag_regex = ~r/<p\s+[^>]*style="([^"]*border-top[^"]*)"[^>]*>.*?<\/p>/s

    case Regex.run(p_tag_regex, html) do
      [_, style_string] ->
        style_map =
          style_string
          |> String.split(";")
          |> Enum.map(&String.trim/1)
          |> Enum.reject(&(&1 == ""))
          |> Enum.map(fn kv ->
            [k, v] = String.split(kv, ":", parts: 2)
            {String.trim(k), String.trim(v)}
          end)
          |> Map.new()

        assert Map.get(style_map, "margin") == "0px"

      nil ->
        flunk("""
        Could not find a <p> tag with 'border-top' in the style attribute.
        HTML was:
        #{html}
        """)
      end
  end

  test "returns error tuple on invalid MJML input" do
    assert {:error, message} = Mjml.to_html(@invalid_mjml)
    assert is_binary(message)
    assert String.contains?(message, "Error") or String.length(message) > 0
  end

  test "renders conditional comments (added in mrml v6.0.0)" do
    assert {:ok, html} = Mjml.to_html(@mjml_with_conditional_comment)
    assert html =~ "<!--[if mso]>"
    assert html =~ "conditional comment for Outlook"
  end

  test "does not render conditional comments if comments are disabled (added in mrml v6.0.0)" do
    assert {:ok, html} = Mjml.to_html(@mjml_with_conditional_comment, keep_comments: false)
    assert html =~ "<!--[if mso]>"
    assert html =~ "conditional comment for Outlook"
  end
end
```

And using mjml_nif v5:

```
❯ mix test apps/mjml_app/test/mjml_nif_test.exs

  1) test does not render conditional comments if comments are disabled (added in mrml v6.0.0) (MjmlNifTest)
     apps/mjml_build/test/mjml_nif_test.exs:75
     match (=) failed
     code:  assert {:ok, html} = Mjml.to_html(@mjml_with_conditional_comment, keep_comments: false)
     left:  {:ok, html}
     right: {:error, "unexpected token in root template at position 38:51"}
     stacktrace:
       test/mjml_nif_test.exs:76: (test)


  2) test renders conditional comments (added in mrml v6.0.0) (MjmlNifTest)
     apps/mjml_build/test/mjml_nif_test.exs:69
     match (=) failed
     code:  assert {:ok, html} = Mjml.to_html(@mjml_with_conditional_comment)
     left:  {:ok, html}
     right: {:error, "unexpected token in root template at position 38:51"}
     stacktrace:
       test/mjml_nif_test.exs:70: (test)


  3) test renders valid MJML input into HTML with proper mj-divider styles (MjmlNifTest)
     apps/mjml_build/test/mjml_nif_test.exs:31
     Assertion with == failed
     code:  assert Map.get(style_map, "margin") == "0px"
     left:  "0px auto"
     right: "0px"
     stacktrace:
       test/mjml_nif_test.exs:52: (test)

.
Finished in 0.1 seconds (0.00s async, 0.1s sync)
4 tests, 3 failures

❯ mix deps.tree | rg '(mjml|mrml|rustler)'
==> mjml_app
mjml_app
│   ├── mjml ~> 5.0 (Hex package)
├── mjml ~> 5.0 (Hex package)
│   └── rustler_precompiled ~> 0.8.1 (Hex package)
│   ├── mjml ~> 5.0 (Hex package)
│   │   └── rustler_precompiled ~> 0.8.1 (Hex package)
│   ├── mjml ~> 5.0 (Hex package)
│   │   └── rustler_precompiled ~> 0.8.1 (Hex package)
│   ├── mjml ~> 5.0 (Hex package)
│   │   └── rustler_precompiled ~> 0.8.1 (Hex package)
│   ├── mjml ~> 5.0 (Hex package)
│   │   └── rustler_precompiled ~> 0.8.1 (Hex package)
│   ├── mjml ~> 5.0 (Hex package)
│   │   └── rustler_precompiled ~> 0.8.1 (Hex package)
│   ├── mjml ~> 5.0 (Hex package)
│   │   └── rustler_precompiled ~> 0.8.1 (Hex package)
```

And in this PR / mjml v6

```
❯ mix test test/mjml_nif_test.exs 
===> Analyzing applications...
===> Compiling hackney
Compiling 2 files (.ex)
Running ExUnit with seed: 383087, max_cases: 20

....
Finished in 0.04 seconds (0.00s async, 0.04s sync)
4 tests, 0 failures

❯ mix deps.tree | rg '(mjml|mrml|rustler)'
├── mjml (/Users/rNoz/projects/mjml_nif)
│   ├── rustler >= 0.0.0 (Hex package)
│   └── rustler_precompiled ~> 0.8.1 (Hex package)
├── rustler >= 0.0.0 (Hex package)
└── rustler_precompiled ~> 0.8.0 (Hex package)
    └── rustler ~> 0.23 (Hex package)
    
❯ mix test test/mjml_nif_test.exs   # using my branch
===> Analyzing applications...
===> Compiling hackney
==> mjml
Compiling 3 files (.ex)
Compiling crate mjml_nif in release mode (native/mjml_nif)
   Compiling proc-macro2 v1.0.94
   Compiling unicode-ident v1.0.18
   Compiling heck v0.5.0
   Compiling regex-lite v0.1.6
   Compiling thiserror v2.0.12
   Compiling inventory v0.3.20
   Compiling cfg-if v1.0.0
   Compiling equivalent v1.0.2
   Compiling hashbrown v0.15.2
   Compiling either v1.15.0
   Compiling libloading v0.8.6
   Compiling rustc-hash v2.1.1
   Compiling itertools v0.14.0
   Compiling htmlparser v0.2.1
   Compiling indexmap v2.8.0
   Compiling rustler v0.36.2
   Compiling quote v1.0.40
   Compiling syn v2.0.100
   Compiling thiserror-impl v2.0.12
   Compiling rustler_codegen v0.36.2
   Compiling enum-as-inner v0.6.1
   Compiling mrml v6.0.0 (https://github.com/jdrouet/mrml?branch=release-plz-2025-05-20T12-58-25Z#35276756)
   Compiling mjml_nif v6.0.0-pre (/Users/rNoz/projects/using_mjml_nif/deps/mjml/native/mjml_nif)
Compiling lib/mjml/native.ex (it's taking more than 10s)
    Finished `release` profile [optimized] target(s) in 17.39s
Generated mjml app
==> using_mjml_nif
Compiling 2 files (.ex)
Generated using_mjml_nif app
Running ExUnit with seed: 314126, max_cases: 20

....
Finished in 0.02 seconds (0.00s async, 0.02s sync)
4 tests, 0 failures

❯ mix deps.tree | rg '(mjml|mrml|rustler)' 
├── mjml (https://github.com/rNoz/mjml_nif.git - rnoz/release-v6)
│   ├── rustler >= 0.0.0 (Hex package)
│   └── rustler_precompiled ~> 0.8.1 (Hex package)
├── rustler >= 0.0.0 (Hex package)
└── rustler_precompiled ~> 0.8.0 (Hex package)
    └── rustler ~> 0.23 (Hex package)
```
