### PR TITLE
feat: enabling ParserOptions and allowing using LocalIncludeLoader and a custom path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ I.e. `mjml_nif 0.x` versions use mrml versions `>= 0.1, < 1.0.0`, and `mjml_nif 
 
 ## [Unreleased]
 
+## [5.1.0] - 2025-06-29
+
+### Changed
+- Allow passing `ParserOptions` and using `LocalIncludeLoader` (`:local`) as well as specifying a custom location to load mjml files via `:local_loader_path`. `NoopIncludeLoader` (`:noop`) is the default loader (no breaking changes).
+
 ## [5.0.0] - 2025-03-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Available rendering options are:
   Defaults to `nil`, which will make the default font families available to
   be used (Open Sans, Droid Sans, Lato, Roboto, and Ubuntu).
 
+Available parsing options are:
+* `include_loader` - the loader to use for `mj-include` tags, accepting `:noop` or `:local`.
+   By default, it uses `:noop`, which means that `mj-include` tags will fail, returning an error
+   indicating that it is "unable to load included template".
+* `local_loader_path` - the root path to use for the `:local` include loader.
+   By default, it is not set (`nil`), using the current working directory as root path.
+
 ```elixir
 mjml = "<mjml>...</mjml>"
 
@@ -63,7 +70,9 @@ opts = [
   social_icon_path: "https://example.com/icons/",
   fonts: %{
       "Noto Color Emoji": "https://fonts.googleapis.com/css?family=Noto+Color+Emoji:400"
-  }
+  },
+  include_loader: :local,
+  local_loader_path: "/path/to/mjml/includes"
 ]
 
 {:ok, html} = Mjml.to_html(mjml, opts)

--- a/lib/mjml/native.ex
+++ b/lib/mjml/native.ex
@@ -36,6 +36,6 @@ defmodule Mjml.Native do
          opts
        end)
 
-  def to_html(_mjml, _render_options), do: error()
+  def to_html(_mjml, _render_options, _parser_options), do: error()
   defp error(), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/lib/mjml/parser_options.ex
+++ b/lib/mjml/parser_options.ex
@@ -1,0 +1,3 @@
+defmodule Mjml.ParserOptions do
+  defstruct include_loader: :noop, local_loader_path: nil
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Mjml.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/adoptoposs/mjml_nif"
-  @version "5.0.0"
+  @version "5.1.0"
 
   def project do
     [

--- a/native/mjml_nif/Cargo.lock
+++ b/native/mjml_nif/Cargo.lock
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "mjml_nif"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "mrml",
  "rustler",

--- a/native/mjml_nif/Cargo.toml
+++ b/native/mjml_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mjml_nif"
-version = "5.0.0"
+version = "5.1.0"
 authors = ["Paul Götze"]
 edition = "2021"
 
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = "0.36.2"
-mrml = { version = "5.0", default-features = false, features = ["parse", "render"] }
+mrml = { version = "5.0", default-features = false, features = ["parse", "render", "local-loader"] }
 
 [features]
 default = ["nif_version_2_15"]

--- a/test/support/partial.mjml
+++ b/test/support/partial.mjml
@@ -1,0 +1,7 @@
+<mj-section>
+  <mj-column>
+    <mj-text>
+      <p>This `partial.mjml` file should be included in another Mjml template.</p>
+    </mj-text>
+  </mj-column>
+</mj-section>


### PR DESCRIPTION
## Feature: include loader

This PR brings:
- Enabling ParserOptions.
- Allow using `include_loader`, specifying a LocalIncludeLoader (`:local`) or NoopIncludeLoader (`:noop`). By default, `:noop` is used to avoid introducing breaking changes.
- Allow specifying a custom root path when including local files (for `LocalIncludeLoader`). It will be the current working dir by default.

Which also fixes: https://github.com/adoptoposs/mjml_nif/issues/122

Including 6 new tests to verify all functionality. One is skipped as I can imagine we would prefer not to show the panic message when running tests.

Feel free to modify anything you want and merge, since I will go on vacations soon.

For instance, I bumped it to 5.1.0 in this repo although mrml is still 5.0, because I am introducing these new features.